### PR TITLE
Update Validate.php

### DIFF
--- a/src/Validate.php
+++ b/src/Validate.php
@@ -271,7 +271,7 @@ class Validate
      * @param string|null $message 验证失败提示信息
      * @return $this
      */
-    public function extend(string $type, callable $callback = null, string $message = null): Validate
+    public function extend(string $type, callable $callback = null, ?string $message = null): Validate
     {
         $this->type[$type] = $callback;
 
@@ -289,7 +289,7 @@ class Validate
      * @param string|null $msg 验证提示信息
      * @return void
      */
-    public function setTypeMsg($type, string $msg = null): void
+    public function setTypeMsg($type, ?string $msg = null): void
     {
         if (is_array($type)) {
             $this->typeMsg = array_merge($this->typeMsg, $type);


### PR DESCRIPTION
fix: 参数隐式可空的参数修改为显式可空类型，以避免出现弃用警告或错误